### PR TITLE
chore: release 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dappbooster",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "description": "Agent-friendly dAppBooster installer that scaffolds Web3 dApps via TUI or non-interactive CLI/CI.",
   "keywords": [
     "dappbooster",
@@ -39,7 +39,9 @@
     "lint": "pnpm biome check",
     "lint:fix": "pnpm biome check --write"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "figures": "^6.1.0",
     "ink": "^5.2.1",


### PR DESCRIPTION
Version bump to `3.2.0` for the Canton stack release (#3, #4).

After merge: tag `v3.2.0` + a GitHub Release triggers the `Release to npm` workflow, which publishes with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)